### PR TITLE
initial implementation of item combination

### DIFF
--- a/content/helpers.spec.ts
+++ b/content/helpers.spec.ts
@@ -1,9 +1,10 @@
 import { addDescriptor, changePrimaryDescriptor, decreaseDescriptorLevel,
-  decreaseDescriptorLevelForPart, decreaseInteractionLevel, getAllDescriptorsForPart, getDescriptorLevel,
+  decreaseDescriptorLevelForPart, decreaseInteractionLevel, getAllDescriptorsForPart, getCombinationBetweenTwoItems, getDescriptorLevel,
   getDescriptorLevelFromPart, getInteraction, getInteractionLevel, getPartWithDescriptor, hasDescriptor,
   hasFoundationalPart, increaseDescriptorLevel, increaseDescriptorLevelForPart, increaseInteractionLevel, setDescriptorLevelForPart,
   setFoundationalPart, setInteraction } from './helpers';
 import { Descriptor, Interaction, ItemConfig } from './interfaces';
+import { Ignites } from './reactions';
 
 test('Setting an interaction should make sure it is at least level 0 and exists', () => {
   const item: ItemConfig = {
@@ -282,4 +283,244 @@ test('Descriptor level setting should work', () => {
   expect(getInteractionLevel(item, Interaction.Carves)).toBe(0);
 });
 
+test('Combining with a foundational source item should not work', () => {
+  const sourceItem: ItemConfig = {
+    name: 'Foundational Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        foundational: true,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 }
+        }
+      }
+    ]
+  };
 
+  const targetItem: ItemConfig = {
+    name: 'Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 }
+        }
+      }
+    ]
+  };
+
+  const combination = getCombinationBetweenTwoItems(sourceItem, targetItem);
+
+  expect(combination.success).toBe(false);
+
+  expect(getDescriptorLevel(combination.newSource, Descriptor.Meat)).toEqual(1);
+  expect(combination.newSource.parts[0].foundational).toBe(true);
+
+  expect(getDescriptorLevel(combination.newTarget, Descriptor.Meat)).toEqual(1);
+});
+
+test('Combining with a foundational target item should not work', () => {
+  const sourceItem: ItemConfig = {
+    name: 'Foundational Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 }
+        }
+      }
+    ]
+  };
+
+  const targetItem: ItemConfig = {
+    name: 'Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        foundational: true,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 }
+        }
+      }
+    ]
+  };
+
+  const combination = getCombinationBetweenTwoItems(sourceItem, targetItem);
+
+  expect(combination.success).toBe(false);
+
+  expect(getDescriptorLevel(combination.newSource, Descriptor.Meat)).toEqual(1);
+
+  expect(getDescriptorLevel(combination.newTarget, Descriptor.Meat)).toEqual(1);
+  expect(combination.newTarget.parts[0].foundational).toBe(true);
+});
+
+test('Combining items with multiple parts should not work', () => {
+  const sourceItem: ItemConfig = {
+    name: 'Compound Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 }
+        }
+      },
+      {
+        name: 'Sand',
+        primaryDescriptor: Descriptor.Sand,
+        descriptors: {
+          [Descriptor.Sand]: { level: 9 }
+        }
+      }
+    ]
+  };
+
+  const targetItem: ItemConfig = {
+    name: 'Compound Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 }
+        }
+      },
+      {
+        name: 'Sand',
+        primaryDescriptor: Descriptor.Sand,
+        descriptors: {
+          [Descriptor.Sand]: { level: 9 }
+        }
+      }
+    ]
+  };
+
+  const combination = getCombinationBetweenTwoItems(sourceItem, targetItem);
+
+  expect(combination.success).toBe(false);
+
+  expect(getDescriptorLevel(combination.newSource, Descriptor.Meat)).toEqual(1);
+  expect(getDescriptorLevel(combination.newSource, Descriptor.Sand)).toEqual(9);
+
+  expect(getDescriptorLevel(combination.newTarget, Descriptor.Meat)).toEqual(1);
+  expect(getDescriptorLevel(combination.newTarget, Descriptor.Sand)).toEqual(9);
+});
+
+test('Combining items that can interact should not work', () => {
+  const sourceItem: ItemConfig = {
+    name: 'Flame',
+    parts: [
+      {
+        name: 'Fire',
+        primaryDescriptor: Descriptor.Hot,
+        descriptors: {
+          [Descriptor.Hot]: { level: 3 },
+          [Descriptor.Blazing]: { level: 3 }
+        }
+      }
+    ],
+    interaction: {
+      name: Interaction.Ignites,
+      level: 3
+    }
+  };
+
+  const targetItem: ItemConfig = {
+    name: 'Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 }
+        }
+      }
+    ]
+  };
+
+  const combination = getCombinationBetweenTwoItems(sourceItem, targetItem);
+
+  expect(combination.success).toBe(false);
+
+  expect(getDescriptorLevel(combination.newSource, Descriptor.Hot)).toEqual(3);
+  expect(getDescriptorLevel(combination.newSource, Descriptor.Blazing)).toEqual(3);
+
+  expect(getDescriptorLevel(combination.newTarget, Descriptor.Meat)).toEqual(1);
+});
+
+test('Combining mismatched items should not work', () => {
+  const sourceItem: ItemConfig = {
+    name: 'Goo',
+    parts: [
+      {
+        name: 'Goo',
+        primaryDescriptor: Descriptor.Sticky,
+        descriptors: {
+          [Descriptor.Sticky]: { level: 1 },
+        }
+      }
+    ]
+  };
+
+  const targetItem: ItemConfig = {
+    name: 'Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 }
+        }
+      }
+    ]
+  };
+
+  const combination = getCombinationBetweenTwoItems(sourceItem, targetItem);
+
+  expect(combination.success).toBe(false);
+
+  expect(getDescriptorLevel(combination.newSource, Descriptor.Sticky)).toEqual(1);
+
+  expect(getDescriptorLevel(combination.newTarget, Descriptor.Meat)).toEqual(1);
+});
+
+test('Combining matching items should work', () => {
+  const sourceItem: ItemConfig = {
+    name: 'Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        descriptors: {
+          [Descriptor.Meat]: { level: 2 }
+        }
+      }
+    ]
+  };
+
+  const targetItem: ItemConfig = {
+    name: 'Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 }
+        }
+      }
+    ]
+  };
+
+  const combination = getCombinationBetweenTwoItems(sourceItem, targetItem);
+
+  expect(combination.success).toBe(true);
+
+  expect(combination.newSource).toBe(undefined);
+
+  expect(getDescriptorLevel(combination.newTarget, Descriptor.Meat)).toEqual(2);
+});

--- a/content/helpers.spec.ts
+++ b/content/helpers.spec.ts
@@ -497,7 +497,7 @@ test('Combining matching items should work', () => {
         name: 'Steak',
         primaryDescriptor: Descriptor.Meat,
         descriptors: {
-          [Descriptor.Meat]: { level: 2 }
+          [Descriptor.Meat]: { level: 1 }
         }
       }
     ]
@@ -523,4 +523,45 @@ test('Combining matching items should work', () => {
   expect(combination.newSource).toBe(undefined);
 
   expect(getDescriptorLevel(combination.newTarget, Descriptor.Meat)).toEqual(2);
+});
+
+test('Combining matching items should work and transfer secondary descriptors', () => {
+  const sourceItem: ItemConfig = {
+    name: 'Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 },
+          [Descriptor.Bright]: { level: 9 },
+          [Descriptor.Cold]: { level: 3 }
+        }
+      }
+    ]
+  };
+
+  const targetItem: ItemConfig = {
+    name: 'Steak',
+    parts: [
+      {
+        name: 'Steak',
+        primaryDescriptor: Descriptor.Meat,
+        descriptors: {
+          [Descriptor.Meat]: { level: 1 },
+          [Descriptor.Cold]: { level: 2 }
+        }
+      }
+    ]
+  };
+
+  const combination = getCombinationBetweenTwoItems(sourceItem, targetItem);
+
+  expect(combination.success).toBe(true);
+
+  expect(combination.newSource).toBe(undefined);
+
+  expect(getDescriptorLevel(combination.newTarget, Descriptor.Meat)).toEqual(2);
+  expect(getDescriptorLevel(combination.newTarget, Descriptor.Bright)).toEqual(9);
+  expect(getDescriptorLevel(combination.newTarget, Descriptor.Cold)).toEqual(5);
 });

--- a/content/helpers.ts
+++ b/content/helpers.ts
@@ -294,31 +294,22 @@ export function getCombinationBetweenTwoItems(sourceItem: ItemConfig, targetItem
     newTarget: targetItem
   });
 
-  // 1) check to see if either item has a foundational part or multiple parts, if so return failedCombination
   if (hasFoundationalPart(sourceItem) || sourceItem.parts.length > 1
    || hasFoundationalPart(targetItem) || targetItem.parts.length > 1) return failedCombination();
 
   const sourcePart = sourceItem.parts[0];
   const targetPart = targetItem.parts[0];
 
-  // 2) check to see if there is an interaction, if so return failedCombination
   const interaction = sourceItem.interaction;
   if (interaction && hasReaction(interaction.name, targetPart.primaryDescriptor))
     return failedCombination();
 
-  // 3) check to see if their parts match, if not return failedCombination
   if (!hasSharedPrimaryDescriptor(sourceItem, targetItem))
     return failedCombination();
 
-  // 4) apply source descriptors to target
-  for (const name in getAllDescriptorsForPart(sourcePart)) {
-    if (name) {
-      const descriptor = Descriptor[name];
-      const descriptorLevel = getDescriptorLevelFromPart(sourcePart, descriptor);
-
-      increaseDescriptorLevelForPart(targetPart, descriptor, descriptorLevel);
-    }
-  }
+  Object.keys(sourcePart.descriptors || {}).forEach(
+    desc => increaseDescriptorLevelForPart(targetPart, desc as Descriptor, sourcePart.descriptors[desc].level ?? 0)
+  );
 
   return {
     success: true,


### PR DESCRIPTION
# Description

Provides a simple implementation of combining two matching items, following the rules laid out in the corresponding issue. This process destroys the `sourceItem` and updates the `targetItem`.

Fixes #14

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (npm run test & npm run e2e) that prove my fix is effective or that my feature works
